### PR TITLE
Upgrade the stale version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,9 +20,9 @@ jobs:
         os: [macos-13,ubuntu-latest,windows-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
In this PR:
- upgraded the python version to 3.8, which is used in the github actions workflow 
  - FYI: https://github.com/inria-UFF/VRPSolverEasy/pull/32#issuecomment-2844810321
- (also) upgraded the checkout, setup-python actions version to the latest
  - FYI: https://github.com/actions/checkout
  - FYI: https://github.com/actions/setup-python